### PR TITLE
feat: add basic HMPL syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,28 @@
+# Node modules
+node_modules/
+client/node_modules/
+server/node_modules/
+
+# TypeScript compilation output
+out/
+client/out/
+server/out/
+testing/
+*.tsbuildinfo
+
+#vsce package
+# VS Code Extension Development & Packaging
+.vscode-test/
+*.vsix
+
+# Log files
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Operating System files
 .DS_Store
+Thumbs.db

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hmpl",
   "displayName": "HMPL",
   "description": "Official HMPL language support for VS Code",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "HMPL.js",
   "publisher": "hmpljs",
   "engines": {

--- a/syntaxes/html.tmLanguage.json
+++ b/syntaxes/html.tmLanguage.json
@@ -32,16 +32,139 @@
       "include": "#cdata"
     },
     {
-      "include": "#tags-valid"
-    },
-    {
-      "include": "#tags-invalid"
+      "include": "#hmpl-block"
+        },
+        {
+          "include": "#tags-valid"
+            },
+            {
+              "include": "#tags-invalid"
     },
     {
       "include": "#entities"
-    }
-  ],
-  "repository": {
+        }
+      ],
+      "repository": {
+    "hmpl-block": {
+      "name": "meta.embedded.block.hmpl",
+      "begin": "\\{\\s*\\{",
+              "beginCaptures": {
+        "0": { "name": "punctuation.definition.tag.begin.hmpl" }
+      },
+      "end": "\\}\\s*\\}",
+              "endCaptures": {
+        "0": { "name": "punctuation.definition.tag.end.hmpl" }
+      },
+              "patterns": [
+                {
+          "include": "#hmpl-request-tag"
+        },
+        {
+          "include": "#hmpl-request-end-tag"
+        }
+      ]
+    },
+    "hmpl-request-tag": {
+      "name": "meta.tag.request.hmpl",
+      "begin": "(#)\\s*(request)\\b",
+              "beginCaptures": {
+        "1": { "name": "punctuation.definition.keyword.hmpl" },
+        "2": { "name": "keyword.control.hmpl" }
+      },
+      "end": "(?=\\}\\s*\\})",
+                  "patterns": [
+        { "include": "#hmpl-attribute" }
+      ]
+    },
+    "hmpl-request-end-tag": {
+      "name": "meta.tag.request.end.hmpl",
+      "match": "(/)\\s*(request)\\b",
+              "captures": {
+        "1": { "name": "punctuation.definition.keyword.hmpl" },
+        "2": { "name": "keyword.control.hmpl" }
+      }
+    },
+    "hmpl-attribute": {
+      "patterns": [
+        {
+          "begin": "\\b(src|after|repeat|method|interval|autoBody|memo|initId|allowedContentTypes|disallowedTags|sanitize|indicators)\\b\\s*(=)",
+          "beginCaptures": {
+            "1": { "name": "entity.other.attribute-name.hmpl" },
+            "2": { "name": "punctuation.separator.key-value.hmpl" }
+          },
+          "end": "(?=\\s*\\b\\w+\\b\\s*=|\\s*\\}\\s*\\})",
+          "patterns": [
+            { "include": "#hmpl-attribute-value" }
+          ]
+        },
+        {
+            "match": "\\b([a-zA-Z0-9\\-]+)\\b",
+            "name": "entity.other.attribute-name.unknown.hmpl"
+        }
+      ]
+    },
+    "hmpl-attribute-value": {
+      "patterns": [
+        {
+          "match": "\\b(true|false)\\b",
+          "name": "constant.language.boolean.hmpl"
+        },
+        {
+          "match": "\\b\\d+(\\.\\d+)?\\b",
+          "name": "constant.numeric.hmpl"
+        },
+        {
+          "begin": "\"",
+          "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.hmpl" } },
+          "end": "\"",
+          "endCaptures": { "0": { "name": "punctuation.definition.string.end.hmpl" } },
+          "name": "string.quoted.double.hmpl",
+          "patterns": [
+            { "include": "#entities" }
+          ]
+        },
+        {
+          "begin": "'",
+          "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.hmpl" } },
+          "end": "'",
+          "endCaptures": { "0": { "name": "punctuation.definition.string.end.hmpl" } },
+          "name": "string.quoted.single.hmpl",
+           "patterns": [
+            { "include": "#entities" }
+          ]
+        },
+        {
+          "begin": "\\[",
+          "beginCaptures": { "0": { "name": "punctuation.definition.array.begin.hmpl" } },
+          "end": "\\]",
+          "endCaptures": { "0": { "name": "punctuation.definition.array.end.hmpl" } },
+          "name": "meta.array.hmpl",
+          "patterns": [
+            {
+              "begin": "\\{",
+              "beginCaptures": { "0": { "name": "punctuation.definition.object.begin.hmpl" } },
+              "end": "\\}",
+              "endCaptures": { "0": { "name": "punctuation.definition.object.end.hmpl" } },
+              "name": "meta.object.hmpl",
+              "patterns": [
+                {
+                  "match": "\\b(trigger|content)\\b\\s*(:)",
+                  "captures": {
+                    "1": { "name": "variable.parameter.hmpl" },
+                    "2": { "name": "punctuation.separator.key-value.hmpl" }
+                  }
+                },
+                { "include": "#hmpl-attribute-value" },
+                { "match": ",", "name": "punctuation.separator.object.hmpl" },
+                { "match": ";", "name": "punctuation.terminator.statement.hmpl"}
+              ]
+            },
+            { "include": "#hmpl-attribute-value" },
+            { "match": ",", "name": "punctuation.separator.array.hmpl" }
+          ]
+        }
+      ]
+    },
     "attribute": {
       "patterns": [
         {


### PR DESCRIPTION
This changes introduces initial syntax highlighting support for HMPL template blocks (`{{ ... }}`) within `.hmpl` files. It builds upon the existing HTML grammar by injecting rules specific to the HMPL language, improving code readability and developer experience.

**Changes:**

*   Modified `syntaxes/html.tmLanguage.json` to include definitions for HMPL constructs.
*   Added highlighting for:
    *   HMPL block delimiters: `{{` and `}}`
    *   Request block tags: `{ {#request ... }}` and `{{/request}}`
    *   Control keywords: `#request`, `/request`
    *   Known attributes within `#request` blocks (e.g., `src`, `after`, `repeat`, `method`, `indicators`, `autoBody`)
    *   Attribute values: strings (single/double-quoted), booleans (`true`/`false`), numbers
    *   Basic structure of JSON5-like arrays (`[...]`) and objects (`{...}`) used in attributes like `indicators`.
    *   Keys within the `indicators` objects (`trigger`, `content`).

**Screenshot:**
![image](https://github.com/user-attachments/assets/d79321c2-27c7-46cf-9afd-324e26c461ab)


**Checklist:**

*   [x] Code follows project conventions.
*   [x] Syntax highlighting works correctly for basic HMPL examples.
*   [x] Changes do not negatively impact standard HTML highlighting.
